### PR TITLE
Change patch target in Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs

### DIFF
--- a/1.5/Source/Faunapedia/Harmony/Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs
+++ b/1.5/Source/Faunapedia/Harmony/Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs
@@ -10,7 +10,7 @@ using Verse;
 
 namespace Faunapedia
 {
-    [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", new Type[] { typeof(Pawn), typeof(Pawn), typeof(bool) })]
+    [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", new Type[] { typeof(Pawn), typeof(Pawn), typeof(string), typeof(string), typeof(bool), typeof(bool) })]
     public static class Patch_InteractionWorker_RecruitAttempt_DoRecruit
     {
         public static void Postfix(Pawn recruitee)


### PR DESCRIPTION
The current harmony patch targets a method to capture the pawn object that was successfully tamed. It's the simpler of two methods and calls the more complicated one with some dummy parameters. However, the method targeted is only ever called as a result of forcing a tame through debugging actions, or when a wounded wild animal is rescued or tended and joins the player faction. This is causing the common route of taming, pawn interacting with animal, not to fire the postfix. This pull request contains a change to the harmony patch annotation to postfix the more complicated method rather than the simpler one in order to monitor all taming activity, not just the circumstances mentioned.