### PR TITLE
Update Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs

### DIFF
--- a/1.5/Source/Faunapedia/Harmony/Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs
+++ b/1.5/Source/Faunapedia/Harmony/Patch_InteractionWorker_RecruitAttempt_DoRecruit.cs
@@ -10,7 +10,7 @@ using Verse;
 
 namespace Faunapedia
 {
-    [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", new Type[] { typeof(Pawn), typeof(Pawn), typeof(string), typeof(string), typeof(bool), typeof(bool) })]
+    [HarmonyPatch(typeof(InteractionWorker_RecruitAttempt), "DoRecruit", new Type[] { typeof(Pawn), typeof(Pawn), typeof(string), typeof(string), typeof(bool), typeof(bool) }, new ArgumentType[] { ArgumentType.Normal, ArgumentType.Normal, ArgumentType.Out, ArgumentType.Out, ArgumentType.Normal, ArgumentType.Normal })]
     public static class Patch_InteractionWorker_RecruitAttempt_DoRecruit
     {
         public static void Postfix(Pawn recruitee)


### PR DESCRIPTION
Harmony doesn't recognize the overloaded DoRecruit method without specifying that the two string parameters are modified by the "out" keyword. This edit has been tested and verified to work in game.